### PR TITLE
Add Jabel and make Java 8 compatibility fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,15 +8,42 @@ group = 'org.taumc'
 version = '1.0-SNAPSHOT'
 
 repositories {
+    maven {
+        name = "gtnh"
+        url = uri("https://nexus.gtnewhorizons.com/repository/public/")
+        content {
+            includeGroup 'com.github.bsideup.jabel'
+        }
+    }
     mavenCentral()
 }
 
 dependencies {
+    annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.1'
+    compileOnly 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.1'
+
     antlr "org.antlr:antlr4:4.13.2"
     implementation 'org.anarres:jcpp:1.4.14'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+        vendor = JvmVendorSpec.AZUL
+    }
+}
+
+configure([tasks.compileJava]) {
+    sourceCompatibility = 17
+    options.release = 8
+
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.AZUL
+    }
 }
 
 generateGrammarSource {

--- a/src/main/java/org/taumc/glsl/Util.java
+++ b/src/main/java/org/taumc/glsl/Util.java
@@ -10,6 +10,7 @@ import org.taumc.glsl.grammar.GLSLLexer;
 import org.taumc.glsl.grammar.GLSLParser;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 public class Util {
 
@@ -61,7 +63,7 @@ public class Util {
     }
 
     public static void rename(GLSLParser.Translation_unitContext root, String oldName, String newName) {
-        ParseTreeWalker.DEFAULT.walk(new Renamer(Map.of(oldName, newName)), root);
+        ParseTreeWalker.DEFAULT.walk(new Renamer(Collections.singletonMap(oldName, newName)), root);
     }
 
     public static void replaceExpression(GLSLParser.Translation_unitContext root, String oldCode, String newCode) {
@@ -116,11 +118,11 @@ public class Util {
     }
 
     public static void renameArray(GLSLParser.Translation_unitContext root, String oldName, String newName, Set<Integer> found) {
-        ParseTreeWalker.DEFAULT.walk(new ArrayExpressionRewriteListener(Map.of(oldName, newName), found), root);
+        ParseTreeWalker.DEFAULT.walk(new ArrayExpressionRewriteListener(Collections.singletonMap(oldName, newName), found), root);
     }
 
     public static void renameFunctionCall(GLSLParser.Translation_unitContext root, String oldName, String newName) {
-        ParseTreeWalker.DEFAULT.walk(new ExpressionRenamer(Map.of(oldName, newName)), root);
+        ParseTreeWalker.DEFAULT.walk(new ExpressionRenamer(Collections.singletonMap(oldName, newName)), root);
     }
 
     public static void renameAndWrapShadow(GLSLParser.Translation_unitContext root, String oldName, String newName) {
@@ -149,7 +151,7 @@ public class Util {
             usedIdentifiers.add(id);
             return true;
         }), root);
-        List<String> functionsToRemove = result.stream().filter(name -> !usedIdentifiers.contains(name) && !name.equals("main")).toList();
+        List<String> functionsToRemove = result.stream().filter(name -> !usedIdentifiers.contains(name) && !name.equals("main")).collect(Collectors.toList());
         // TODO - remove all the functions in one walk of the tree
         for (String name : functionsToRemove) {
             removeFunction(root, name);


### PR DESCRIPTION
Adds Jabel as a dependency for modern Java syntax with java 8 compatibility.

It pulls Jabel from the GTNH maven because for whatever reason the latest version of Jabel has never been put on maven central.

It also replaces the few incompatibilities remaining with Java 8, namely usage of `Map.of()` and `List.of()`. These have been replaced with `Collections.singletonMap()` and `Collectors.toList()`, respectively.