### PR TITLE
Update initialize() to not shadow a global var

### DIFF
--- a/src/main/java/org/taumc/glsl/Transformer.java
+++ b/src/main/java/org/taumc/glsl/Transformer.java
@@ -535,7 +535,7 @@ public class Transformer {
 
     public void initialize(GLSLParser.Single_declarationContext declarationContext, String name) {
         if (declarationContext.fully_specified_type().type_specifier().type_specifier_nonarray().getChild(0) instanceof TerminalNode node && node.getSymbol() instanceof CommonToken token) {
-            String insert = token.getText() + " " + name + " = " + BuiltinFunction.getByType(token.getType()).getInitializer() + ";" ;
+            String insert = name + " = " + BuiltinFunction.getByType(token.getType()).getInitializer() + ";" ;
             prependMain(insert);
         }
     }


### PR DESCRIPTION
Additional context:
I was trying to get Bliss working on Angelica, and was getting a warning about 'error: fragment shader varying tempOffsets was not written by vertex shader' I found `flat varying float tempOffsets` properly declared, and some intialized it in main with `tempOffsets = HaltonSeq2(frameCounter%10000)` but others didn't.  initialize() was injecting `type name = default()` which shadowed the global var.  This PR adjusts that to initialize, not shadow.

Tested on Angelica, and Celeritas forge 1.20.1 with Bliss and Comp+EP